### PR TITLE
Adjust photo capture interval to 30 minutes

### DIFF
--- a/every1h_photo_lux.py
+++ b/every1h_photo_lux.py
@@ -36,5 +36,5 @@ while True:
 
     print(f"[{now}] 撮影・照度保存完了")
 
-    # 6. 1時間待機 (3600秒)
-    time.sleep(3600)
+    # 6. 30分待機 (1800秒)
+    time.sleep(1800)


### PR DESCRIPTION
## Summary
- update the periodic capture script to sleep for 30 minutes instead of an hour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0b78a9e94832b851ebee034785256