### PR TITLE
Fix unmatched parenthesis in master.py

### DIFF
--- a/master.py
+++ b/master.py
@@ -46,6 +46,8 @@ def _resolve_input_folder() -> Path:
         )
         return processed_dirs[0]
 
+    raise FileNotFoundError(
+        "入力フォルダが見つかりません。REVIEW_INPUT_FOLDER を指定してください。"
     )
 
 


### PR DESCRIPTION
## Summary
- replace stray closing parenthesis in `_resolve_input_folder` with error handling that raises a helpful message when no processed folders are found

## Testing
- python -m compileall master.py

------
https://chatgpt.com/codex/tasks/task_e_68d4b09a93e4832bb9f4f3b4cccfb6b0