### PR TITLE
Restore input folder fallbacks

### DIFF
--- a/master.py
+++ b/master.py
@@ -30,6 +30,12 @@ def _resolve_input_folder() -> Path:
     if env_input:
         return Path(env_input)
 
+    if not DEFAULT_INPUT_ROOT.exists():
+        raise FileNotFoundError(
+            "入力ルートが見つかりません。Z: ドライブの割当や NAS 接続を確認してください: "
+            f"{DEFAULT_INPUT_ROOT}"
+        )
+
     today_suffix = datetime.now().strftime("%Y%m%d_processed")
     today_candidate = DEFAULT_INPUT_ROOT / today_suffix
     if today_candidate.is_dir():
@@ -46,6 +52,24 @@ def _resolve_input_folder() -> Path:
         )
         return processed_dirs[0]
 
+    dated_dirs = sorted(
+        (
+            path
+            for path in DEFAULT_INPUT_ROOT.iterdir()
+            if path.is_dir() and path.name[:8].isdigit()
+        ),
+        key=lambda path: path.name,
+        reverse=True,
+    )
+    if dated_dirs:
+        logging.getLogger(__name__).warning(
+            "*_processed フォルダが見つからないため %s を使用します", dated_dirs[0]
+        )
+        return dated_dirs[0]
+
+    raise FileNotFoundError(
+        "入力フォルダが見つかりません。REVIEW_INPUT_FOLDER を設定するか、"
+        f"{DEFAULT_INPUT_ROOT} に 日付フォルダ (例: 20250101_processed) を用意してください。"
     )
 
 


### PR DESCRIPTION
## Summary
- restore the existence check for the default input root so a clearer error is raised when the NAS drive is unavailable
- reinstate fallbacks to the latest *_processed folder or dated directory when no explicit input is provided
- provide a more actionable error message when no candidate folders are found

## Testing
- python -m compileall master.py

------
https://chatgpt.com/codex/tasks/task_e_68d4b09a93e4832bb9f4f3b4cccfb6b0