### PR TITLE
Improve missing input folder error message

### DIFF
--- a/master.py
+++ b/master.py
@@ -32,6 +32,8 @@ def _resolve_input_folder() -> Path:
 
     if not DEFAULT_INPUT_ROOT.exists():
         raise FileNotFoundError(
+            "既定の入力ルートが見つかりません。REVIEW_INPUT_FOLDER を設定するか、"
+            f"{DEFAULT_INPUT_ROOT} に処理済みフォルダを配置してください。"
         )
 
     today_suffix = datetime.now().strftime("%Y%m%d_processed")


### PR DESCRIPTION
## Summary
- add a clear message when the default input folder is missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4e0fc6f98832ba000fc9e671d790e