### PR TITLE
Add configurable input root for master pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # camera1
+
 PICUのカメラを開発
+
+## master.py の使い方
+
+### 入力フォルダの指定
+
+`master.py` はレビュー対象の画像を格納したフォルダを自動的に探します。標準では以下の順で探索します。
+
+1. `--input` で直接指定したフォルダ
+2. 環境変数 `REVIEW_INPUT_FOLDER`
+3. `--input-root` または環境変数 `REVIEW_INPUT_ROOT` で指定したルート配下にある最新の日付フォルダ
+4. リポジトリに同梱されている既定候補 (`pi-vital2/` など)
+
+`--input-root`/`REVIEW_INPUT_ROOT` を利用すると、毎日生成される `20250101_processed` のようなフォルダ群が配置されているルートパスを一度指定するだけで、最新のフォルダが自動的に選択されます。
+
+### 実行例
+
+```powershell
+# フォルダを直接指定する場合
+python master.py --input "Z:\Raspi_face\pi-vital2\20250101_processed"
+
+# ルートを指定して最新のフォルダを自動選択する場合
+python master.py --input-root "Z:\Raspi_face\pi-vital2"
+
+# 環境変数を利用する場合 (PowerShell)
+$env:REVIEW_INPUT_ROOT = "Z:\Raspi_face\pi-vital2"
+python master.py
+```
+
+いずれの方法でもフォルダが見つからない場合は、エラーメッセージに表示される候補パスのいずれかに日付フォルダを用意してください。

--- a/master.py
+++ b/master.py
@@ -53,7 +53,10 @@ def _resolve_output_folder(override: Path | None = None) -> Path:
     return Path(os.environ.get("REVIEW_OUTPUT_ROOT", str(DEFAULT_OUTPUT_FOLDER)))
 
 
-def _resolve_input_folder(override: Path | None = None) -> Path:
+def _resolve_input_folder(
+    override: Path | None = None,
+    override_root: Path | None = None,
+) -> Path:
     if override is not None:
         override_path = Path(override)
         if not override_path.exists():
@@ -66,7 +69,17 @@ def _resolve_input_folder(override: Path | None = None) -> Path:
 
     logger = logging.getLogger(__name__)
 
-    default_roots = _default_input_root_candidates()
+    roots: tuple[Path, ...]
+    if override_root is not None:
+        roots = (Path(override_root),)
+    else:
+        env_root = os.environ.get("REVIEW_INPUT_ROOT")
+        if env_root:
+            roots = (Path(env_root),)
+        else:
+            roots = _default_input_root_candidates()
+
+    default_roots = roots
     for default_root in default_roots:
         if not default_root.exists():
             continue
@@ -117,13 +130,21 @@ def main() -> None:
         help="レビュー対象となる処理済み画像フォルダのパス。",
     )
     parser.add_argument(
+        "--input-root",
+        type=Path,
+        help=(
+            "処理済み画像フォルダが格納されたルートパス。"
+            "最新の日付フォルダを自動的に選択します。"
+        ),
+    )
+    parser.add_argument(
         "--output",
         type=Path,
         help="レビュー結果を書き出すフォルダのパス。",
     )
     args = parser.parse_args()
 
-    input_folder = _resolve_input_folder(args.input)
+    input_folder = _resolve_input_folder(args.input, args.input_root)
     output_folder = _resolve_output_folder(args.output)
 
     camera_id = os.environ.get("CAMERA_ID")


### PR DESCRIPTION
## Summary
- allow master.py to accept an input root via --input-root or REVIEW_INPUT_ROOT
- improve error handling to check the override paths before falling back to default candidates
- document the new usage patterns and options in README.md

## Testing
- python -m compileall master.py processing_pipeline.py change.py every1h_photo_lux.py pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d4f1b9af98832bae326ced0a5a9055