### PR TITLE
Add automated pipeline mode to master script

### DIFF
--- a/master.py
+++ b/master.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import time
 from datetime import datetime
 from pathlib import Path
 
+from pipeline import CYCLE_INTERVAL_SECONDS, run_cycle
 from processing_pipeline import (
     CAMERA_CROP_CONFIGS,
     DEFAULT_CROP,
@@ -125,6 +127,15 @@ def main() -> None:
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
+        "--mode",
+        choices=("pipeline", "review"),
+        default="pipeline",
+        help=(
+            "pipeline: 全自動で撮影からレビューまで実行します / "
+            "review: 既存の処理済みフォルダのみレビューします"
+        ),
+    )
+    parser.add_argument(
         "--input",
         type=Path,
         help="レビュー対象となる処理済み画像フォルダのパス。",
@@ -142,9 +153,16 @@ def main() -> None:
         type=Path,
         help="レビュー結果を書き出すフォルダのパス。",
     )
+    parser.add_argument(
+        "--continuous",
+        action="store_true",
+        help=(
+            "pipelineモード時に周期処理を止めずに継続します。"
+            "指定しない場合は1サイクルのみ実行します。"
+        ),
+    )
     args = parser.parse_args()
 
-    input_folder = _resolve_input_folder(args.input, args.input_root)
     output_folder = _resolve_output_folder(args.output)
 
     camera_id = os.environ.get("CAMERA_ID")
@@ -152,6 +170,32 @@ def main() -> None:
 
     review_manager = ReviewManager(output_folder)
     review_aborted = False
+
+    if args.mode == "pipeline":
+        try:
+            while True:
+                try:
+                    run_cycle(
+                        model,
+                        review_manager,
+                        announce_sleep=args.continuous,
+                    )
+                except ReviewAborted:
+                    review_aborted = True
+                    break
+
+                if not args.continuous:
+                    break
+
+                time.sleep(CYCLE_INTERVAL_SECONDS)
+        finally:
+            review_manager.close()
+
+        if review_aborted:
+            print("[INFO] オペレータがレビューを中断しました。")
+        return
+
+    input_folder = _resolve_input_folder(args.input, args.input_root)
 
     try:
         process_folder(

--- a/pipeline.py
+++ b/pipeline.py
@@ -47,7 +47,12 @@ CYCLE_INTERVAL_SECONDS = _env_interval("PIPELINE_INTERVAL_SECONDS", 1800)
 OUTPUT_ROOT = Path(os.environ.get("PIPELINE_OUTPUT_ROOT", str(DEFAULT_OUTPUT_ROOT)))
 
 
-def run_cycle(model: "YOLO", review_manager: ReviewManager) -> None:
+def run_cycle(
+    model: "YOLO",
+    review_manager: ReviewManager,
+    *,
+    announce_sleep: bool = True,
+) -> None:
     cycle_started = datetime.now()
     print(f"[INFO] Pipeline cycle started at {cycle_started:%Y-%m-%d %H:%M:%S}")
 
@@ -77,7 +82,8 @@ def run_cycle(model: "YOLO", review_manager: ReviewManager) -> None:
         except Exception as exc:
             print(f"[ERROR] {name}: 処理中にエラーが発生しました: {exc}")
 
-    print(f"[INFO] Cycle finished. Sleeping for {CYCLE_INTERVAL_SECONDS} seconds.")
+    if announce_sleep:
+        print(f"[INFO] Cycle finished. Sleeping for {CYCLE_INTERVAL_SECONDS} seconds.")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- add a pipeline mode to `master.py` so that launching the script can capture, correct, process, and save images without pre-generated input folders
- allow continuous scheduling of pipeline cycles from `master.py` with a `--continuous` flag while preserving the existing review-only mode
- make `pipeline.run_cycle` optionally suppress the sleep announcement so that it can be reused for single-shot runs

## Testing
- python -m py_compile master.py pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d4f3e7bc5c832ba75ea11192884853