### PR TITLE
Fix master pipeline CLI options

### DIFF
--- a/master.py
+++ b/master.py
@@ -154,7 +154,9 @@ def main() -> None:
         help="レビュー結果を書き出すフォルダのパス。",
     )
     parser.add_argument(
-        ),
+        "--once",
+        action="store_true",
+        help="pipeline モードで 1 サイクルのみ実行します。",
     )
     args = parser.parse_args()
 
@@ -174,13 +176,13 @@ def main() -> None:
                     run_cycle(
                         model,
                         review_manager,
-
+                        announce_sleep=not args.once,
                     )
                 except ReviewAborted:
                     review_aborted = True
                     break
 
-
+                if args.once:
                     break
 
                 time.sleep(CYCLE_INTERVAL_SECONDS)


### PR DESCRIPTION
## Summary
- add a --once flag to master.py so the pipeline mode can run a single cycle
- ensure the run_cycle call passes announce_sleep based on the --once flag and exit after the first iteration when requested

## Testing
- python -m compileall master.py

------
https://chatgpt.com/codex/tasks/task_e_68d5e7d943fc832baf22b2f12e77ee64