### PR TITLE
Fix review manager display scaling attribute initialization

### DIFF
--- a/processing_pipeline.py
+++ b/processing_pipeline.py
@@ -89,6 +89,9 @@ class ReviewManager:
     )
     quit_keys: Sequence[str] = tuple(REVIEW_QUIT_KEYS)
     window_name: str = REVIEW_WINDOW_NAME
+    display_max_dimension: int | None = field(
+        default_factory=_default_display_max_dimension
+    )
       
     _destinations: dict[str, Path] = field(init=False, repr=False)
     _key_bindings: dict[str, str] = field(init=False, repr=False)


### PR DESCRIPTION
## Summary
- ensure `ReviewManager` stores the configured maximum display dimension so the review UI can scale images

## Testing
- python -m compileall processing_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d5fd479924832ba7673230b29e75e3