### PR TITLE
Add option to defer interactive review during pipeline capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,13 @@ python master.py
 ```
 
 いずれの方法でもフォルダが見つからない場合は、エラーメッセージに表示される候補パスのいずれかに日付フォルダを用意してください。
+
+### パイプラインモードでレビューを後回しにする
+
+撮影を定期的に続けつつ、レビューは後からまとめて行いたい場合は `--defer-review` を利用します。
+
+```powershell
+python master.py --mode pipeline --defer-review
+```
+
+このモードでは撮影とファイル転送のみを行い、分類は `master.py --mode review` で後から実施してください。`pipeline.py` を直接実行する場合は、環境変数 `PIPELINE_DEFER_REVIEW=1` を設定すると同じ挙動になります。

--- a/master.py
+++ b/master.py
@@ -158,17 +158,31 @@ def main() -> None:
         action="store_true",
         help="pipeline モードで 1 サイクルのみ実行します。",
     )
+    parser.add_argument(
+        "--defer-review",
+        action="store_true",
+        help=(
+            "pipeline モードでレビューを後回しにします。撮影とファイル転送のみを行い、"
+            "分類は review モードで実施してください。"
+        ),
+    )
     args = parser.parse_args()
 
     output_folder = _resolve_output_folder(args.output)
 
     camera_id = os.environ.get("CAMERA_ID")
-    model, _ = load_yolo_model(camera_id)
+    requires_model = not (args.mode == "pipeline" and args.defer_review)
+    model = None
+    if requires_model:
+        model, _ = load_yolo_model(camera_id)
 
-    review_manager = ReviewManager(output_folder)
+    review_manager: ReviewManager | None = None
     review_aborted = False
 
     if args.mode == "pipeline":
+
+        if not args.defer_review:
+            review_manager = ReviewManager(output_folder)
 
         try:
             while True:
@@ -177,6 +191,7 @@ def main() -> None:
                         model,
                         review_manager,
                         announce_sleep=not args.once,
+                        defer_review=args.defer_review,
                     )
                 except ReviewAborted:
                     review_aborted = True
@@ -187,11 +202,14 @@ def main() -> None:
 
                 time.sleep(CYCLE_INTERVAL_SECONDS)
         finally:
-            review_manager.close()
+            if review_manager is not None:
+                review_manager.close()
 
         if review_aborted:
             print("[INFO] オペレータがレビューを中断しました。")
         return
+
+    review_manager = ReviewManager(output_folder)
 
     input_folder = _resolve_input_folder(args.input, args.input_root)
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -47,16 +47,35 @@ CYCLE_INTERVAL_SECONDS = _env_interval("PIPELINE_INTERVAL_SECONDS", 1800)
 OUTPUT_ROOT = Path(os.environ.get("PIPELINE_OUTPUT_ROOT", str(DEFAULT_OUTPUT_ROOT)))
 
 
+def _env_flag(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    print(f"[WARN] Invalid boolean for {name}: {raw!r}. Using default {default}.")
+    return default
+
+
 def run_cycle(
-    model: "YOLO",
-    review_manager: ReviewManager,
+    model: "YOLO" | None,
+    review_manager: ReviewManager | None,
     *,
     announce_sleep: bool = True,
+    defer_review: bool = False,
 ) -> None:
     cycle_started = datetime.now()
     print(f"[INFO] Pipeline cycle started at {cycle_started:%Y-%m-%d %H:%M:%S}")
 
     ensure_save_directories(CAMERA_CONFIGS, cycle_started)
+
+    if defer_review:
+        print(
+            "[INFO] レビューを後回しにしています。必要になったら master.py --mode review で分類してください。"
+        )
 
     for config in CAMERA_CONFIGS:
         name = config.label()
@@ -68,6 +87,16 @@ def run_cycle(
 
         image_path = Path(result.image_path)
         lux_path = Path(result.lux_path)
+        if defer_review:
+            print(
+                "[INFO] レビュー保留: %s / 後で review モードで分類してください。" % image_path
+            )
+            print(f"[INFO] 参考: 照度ログ → {lux_path}")
+            continue
+
+        if model is None or review_manager is None:
+            raise RuntimeError("defer_review=False の場合、model と review_manager が必要です。")
+
         try:
             process_image(
                 image_path,
@@ -90,20 +119,32 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
 
     camera_id = os.environ.get("CAMERA_ID")
-    model, _ = load_yolo_model(camera_id)
-    review_manager = ReviewManager(OUTPUT_ROOT)
+    defer_review = _env_flag("PIPELINE_DEFER_REVIEW", False)
+
+    model = None
+    if not defer_review:
+        model, _ = load_yolo_model(camera_id)
+
+    review_manager: ReviewManager | None = None
+    if not defer_review:
+        review_manager = ReviewManager(OUTPUT_ROOT)
 
     try:
         while True:
             try:
-                run_cycle(model, review_manager)
+                run_cycle(
+                    model,
+                    review_manager,
+                    defer_review=defer_review,
+                )
             except ReviewAborted:
                 print("[INFO] オペレータがレビューを中断しました。")
                 break
 
             time.sleep(CYCLE_INTERVAL_SECONDS)
     finally:
-        review_manager.close()
+        if review_manager is not None:
+            review_manager.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a --defer-review switch to master.py pipeline mode so captures continue without blocking on manual labeling
- allow pipeline.py to skip loading the YOLO model and interactive prompts when PIPELINE_DEFER_REVIEW=1
- document how to run the deferred review workflow in README.md

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d62763835c832bb861fb060b698586