### PR TITLE
Decouple capture from review in pipeline cycle

### DIFF
--- a/master.py
+++ b/master.py
@@ -192,10 +192,12 @@ def main() -> None:
     review_manager: ReviewManager | None = None
     review_aborted = False
 
+    defer_review = args.defer_review or _env_flag("PIPELINE_DEFER_REVIEW", False)
+    model = None
+
     if args.mode == "pipeline":
         if not defer_review:
-            review_manager = ReviewManager(output_folder)
-
+            model, _ = load_yolo_model(camera_id)
             review_manager = ReviewManager(output_folder)
 
         try:
@@ -205,7 +207,7 @@ def main() -> None:
                         model,
                         review_manager,
                         announce_sleep=not args.once,
-
+                        defer_review=defer_review,
                     )
                 except ReviewAborted:
                     review_aborted = True
@@ -223,6 +225,7 @@ def main() -> None:
             print("[INFO] オペレータがレビューを中断しました。")
         return
 
+    model, _ = load_yolo_model(camera_id)
     review_manager = ReviewManager(output_folder)
 
     input_folder = _resolve_input_folder(args.input, args.input_root)

--- a/pipeline.py
+++ b/pipeline.py
@@ -77,6 +77,8 @@ def run_cycle(
             "[INFO] レビューを後回しにしています。必要になったら master.py --mode review で分類してください。"
         )
 
+    capture_results: list[tuple[str, Path, Path]] = []
+
     for config in CAMERA_CONFIGS:
         name = config.label()
         try:
@@ -87,16 +89,21 @@ def run_cycle(
 
         image_path = Path(result.image_path)
         lux_path = Path(result.lux_path)
+        capture_results.append((name, image_path, lux_path))
+
         if defer_review:
             print(
                 "[INFO] レビュー保留: %s / 後で review モードで分類してください。" % image_path
             )
             print(f"[INFO] 参考: 照度ログ → {lux_path}")
-            continue
 
-        if model is None or review_manager is None:
-            raise RuntimeError("defer_review=False の場合、model と review_manager が必要です。")
+    if defer_review:
+        return
 
+    if model is None or review_manager is None:
+        raise RuntimeError("defer_review=False の場合、model と review_manager が必要です。")
+
+    for name, image_path, lux_path in capture_results:
         try:
             process_image(
                 image_path,


### PR DESCRIPTION
## Summary
- collect capture results for each camera before starting the interactive review work
- exit the cycle early when review is deferred so shooting is never blocked on labelling

## Testing
- python -m compileall master.py pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d647e704e0832b9558abbc7c51f6da