### PR TITLE
Default pipeline to capture-only mode with deferred review

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,16 @@ python master.py
 
 いずれの方法でもフォルダが見つからない場合は、エラーメッセージに表示される候補パスのいずれかに日付フォルダを用意してください。
 
-### パイプラインモードでレビューを後回しにする
+### パイプラインモードのレビュー運用
 
-撮影を定期的に続けつつ、レビューは後からまとめて行いたい場合は `--defer-review` を利用します。
+`master.py --mode pipeline` は既定でレビューを後回しにし、撮影と転送だけを継続します。手が空いたタイミングで以下のようにレビューを実行してください。
 
 ```powershell
-python master.py --mode pipeline --defer-review
+python master.py --mode review --input "Z:\Raspi_face\pi-vital2\20250101"
+```
+
+撮影直後にレビューも同時に行いたい場合は `--review-now` オプションを付けてください。
+
+```powershell
+python master.py --mode pipeline --review-now
 ```

--- a/master.py
+++ b/master.py
@@ -175,14 +175,23 @@ def main() -> None:
         action="store_true",
         help="pipeline モードで 1 サイクルのみ実行します。",
     )
-    parser.add_argument(
+    review_mode = parser.add_mutually_exclusive_group()
+    review_mode.add_argument(
+        "--review-now",
+        dest="defer_review",
+        action="store_false",
+        help="pipeline モードで従来どおり撮影直後にFace Reviewを実施します。",
+    )
+    review_mode.add_argument(
         "--defer-review",
+        dest="defer_review",
         action="store_true",
         help=(
             "pipeline モードでレビューを後回しにします。撮影とファイル転送のみを行い、"
             "分類は review モードで実施してください。"
         ),
     )
+    parser.set_defaults(defer_review=None)
     args = parser.parse_args()
 
     output_folder = _resolve_output_folder(args.output)
@@ -192,7 +201,11 @@ def main() -> None:
     review_manager: ReviewManager | None = None
     review_aborted = False
 
-    defer_review = args.defer_review or _env_flag("PIPELINE_DEFER_REVIEW", False)
+    env_defer_review = _env_flag("PIPELINE_DEFER_REVIEW", True)
+    if args.defer_review is None:
+        defer_review = env_defer_review
+    else:
+        defer_review = args.defer_review
     model = None
 
     if args.mode == "pipeline":

--- a/pipeline.py
+++ b/pipeline.py
@@ -79,6 +79,8 @@ def run_cycle(
 
     capture_results: list[tuple[str, Path, Path]] = []
 
+    review_folders: set[Path] = set()
+
     for config in CAMERA_CONFIGS:
         name = config.label()
         try:
@@ -91,6 +93,8 @@ def run_cycle(
         lux_path = Path(result.lux_path)
         capture_results.append((name, image_path, lux_path))
 
+        review_folders.add(image_path.parent)
+
         if defer_review:
             print(
                 "[INFO] レビュー保留: %s / 後で review モードで分類してください。" % image_path
@@ -98,6 +102,14 @@ def run_cycle(
             print(f"[INFO] 参考: 照度ログ → {lux_path}")
 
     if defer_review:
+        if review_folders:
+            print("[INFO] 後からレビューするフォルダの候補:")
+            for folder in sorted(review_folders):
+                print(f"        - {folder}")
+            print(
+                "[INFO] 例: python master.py --mode review --input "
+                "\"<上記のフォルダ>\""
+            )
         return
 
     if model is None or review_manager is None:
@@ -126,7 +138,7 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
 
     camera_id = os.environ.get("CAMERA_ID")
-    defer_review = _env_flag("PIPELINE_DEFER_REVIEW", False)
+    defer_review = _env_flag("PIPELINE_DEFER_REVIEW", True)
 
     model = None
     if not defer_review:


### PR DESCRIPTION
## Summary
- default the automated pipeline to defer face review so captures keep running unattended
- add explicit --review-now flag and improve deferred review logging guidance
- document the new review flow in the README

## Testing
- python -m compileall master.py pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d75d3f4cf4832ba6b548b7349e436a